### PR TITLE
Target .NET Framework 4.6

### DIFF
--- a/toofz.NecroDancer.WebClient/Web.config
+++ b/toofz.NecroDancer.WebClient/Web.config
@@ -25,17 +25,17 @@
 
   <system.codedom>
     <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701" />
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>
 
   <system.web>
-    <compilation debug="true" targetFramework="4.5" />
+    <compilation debug="true" targetFramework="4.6" />
     <httpModules>
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" />
     </httpModules>
-    <httpRuntime targetFramework="4.5" enableVersionHeader="false" />
+    <httpRuntime targetFramework="4.6" enableVersionHeader="false" />
   </system.web>
 
   <system.webServer>
@@ -63,30 +63,6 @@
 
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
-      </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.2.1" newVersion="4.0.2.1" />

--- a/toofz.NecroDancer.WebClient/packages.config
+++ b/toofz.NecroDancer.WebClient/packages.config
@@ -1,22 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Humanizer.Core" version="2.2.0" targetFramework="net45" />
-  <package id="log4net" version="2.0.8" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.4.1" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.Log4NetAppender" version="2.4.0" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.4.1" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.Web" version="2.4.1" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.1" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
-  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.7" targetFramework="net45" />
-  <package id="Microsoft.Net.Compilers" version="2.3.1" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net45" />
-  <package id="toofz" version="3.1.0" targetFramework="net45" />
+  <package id="Humanizer.Core" version="2.2.0" targetFramework="net46" />
+  <package id="log4net" version="2.0.8" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.4.1" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.Log4NetAppender" version="2.4.0" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.4.1" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.Web" version="2.4.1" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.1" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0" targetFramework="net46" />
+  <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net46" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.7" targetFramework="net46" />
+  <package id="Microsoft.Net.Compilers" version="2.3.1" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net46" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net46" />
+  <package id="toofz" version="3.1.0" targetFramework="net46" />
 </packages>

--- a/toofz.NecroDancer.WebClient/toofz.NecroDancer.WebClient.csproj
+++ b/toofz.NecroDancer.WebClient/toofz.NecroDancer.WebClient.csproj
@@ -16,7 +16,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>toofz.NecroDancer.WebClient</RootNamespace>
     <AssemblyName>toofz.NecroDancer.WebClient</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
@@ -76,7 +76,7 @@
       <HintPath>..\packages\Microsoft.ApplicationInsights.WindowsServer.2.4.1\lib\net45\Microsoft.AI.WindowsServer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights.Log4NetAppender, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.Log4NetAppender.2.4.0\lib\net45\Microsoft.ApplicationInsights.Log4NetAppender.dll</HintPath>
@@ -91,9 +91,15 @@
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.1\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
     </Reference>
@@ -112,7 +118,7 @@
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="toofz, Version=3.1.0.47, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\toofz.3.1.0\lib\net45\toofz.dll</HintPath>
     </Reference>
@@ -141,9 +147,9 @@
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
-    <None Include="packages.config">
+    <Content Include="packages.config">
       <SubType>Designer</SubType>
-    </None>
+    </Content>
     <Content Include="Web.config">
       <SubType>Designer</SubType>
     </Content>


### PR DESCRIPTION
Dependency diagnostics are made available for Application Insights when targeting .NET Framework 4.6.